### PR TITLE
fix: 修复不能获取当地天气和月相的问题 

### DIFF
--- a/.obsidian/plugins/templater-obsidian/data.json
+++ b/.obsidian/plugins/templater-obsidian/data.json
@@ -1,21 +1,12 @@
 {
   "command_timeout": 20,
   "templates_folder": "Templates",
-  "templates_pairs": [
-    [
-      "getWeather",
-      "curl wttr.in/\"$(curl -s --header \"user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36\" https://api.ip.sb/geoip | /opt/homebrew/bin/jq -r \".city\" | sed 's/ /%20/')\"\\?format=\"%l+%c%t\""
-    ],
-    [
-      "getMoon",
-      "curl wttr.in/\"$(curl -s --header \"user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36\" https://api.ip.sb/geoip | /opt/homebrew/bin/jq -r \".city\" | sed 's/ /%20/')\"\\?format=\"%m\""
-    ]
-  ],
+  "templates_pairs": [],
   "trigger_on_file_creation": true,
   "auto_jump_to_cursor": false,
   "enable_system_commands": true,
   "shell_path": "/bin/zsh",
-  "user_scripts_folder": "",
+  "user_scripts_folder": "Templates/Scripts",
   "enable_folder_templates": true,
   "folder_templates": [
     {

--- a/Templates/Scripts/getMoon.js
+++ b/Templates/Scripts/getMoon.js
@@ -1,0 +1,36 @@
+async function getWeatherProto(city = 'beijing', format = "地点： %l \\n天气：%c %C 气温：%t 风力：%w  \\n月相：%m 日出时间：%S 日落时间：%s") {
+    const url = "https://wttr.in/" + city + "?Tm2&lang=zh-cn&format=" + format;
+    // const url = "https://wtr.in/" + city + "?Tm2&lang=zh-cn&format=" + format;
+
+    try {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.text();
+        return data;
+    } catch (error) {
+        console.error("Error fetching weather data:", error);
+        throw error; 
+    }
+}
+
+async function getMoon() {
+
+    try {
+        const city = 'Guangzhou';
+        const format = "%m";
+        const moon = await getWeatherProto(city, format);
+        return moon;
+    } catch (error) {
+        return "None";
+    }
+
+}
+// getMoon().then(value => {
+//     console.log(value);
+// });
+
+module.exports = getMoon

--- a/Templates/Scripts/getWeather.js
+++ b/Templates/Scripts/getWeather.js
@@ -1,0 +1,62 @@
+// const getCity = require('./getCity'); 在 Obsidian 中无效
+
+async function getCity() {
+    const url = "https://api.ip.sb/geoip";
+    // const url = "https://bpi.ip.sb/geoip";
+    const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
+
+    try {
+        const response = await fetch(url, {
+            headers: {
+                "User-Agent": userAgent,
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const city = data.city
+        return city
+    } catch (error) {
+        console.error("Error fetching city data:", error);
+        throw error; 
+    }
+}
+
+async function getWeatherProto(city = 'beijing', format = "地点： %l \\n天气：%c %C 气温：%t 风力：%w  \\n月相：%m 日出时间：%S 日落时间：%s") {
+    const url = "https://wttr.in/" + city + "?Tm2&lang=zh-cn&format=" + format;
+    // const url = "https://wtr.in/" + city + "?Tm2&lang=zh-cn&format=" + format;
+
+    try {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.text();
+        return data;
+    } catch (error) {
+        console.error("Error fetching weather data:", error);
+        throw error; 
+    }
+}
+
+// get weather by location 
+async function getWeather() {
+    try {
+        const city = await getCity();
+        const format = "%l+%c%t";
+        const weather = await getWeatherProto(city, format);
+        return weather;
+    } catch (error) {
+        return "None";
+    }
+}
+// getWeather().then(value => {
+//     console.log(value);
+// });
+
+module.exports = getWeather


### PR DESCRIPTION
Windows下的 shell 执行命令会有各种各样的问题 #1 ，所以让 Templater 获取天气函数不通过 System Command 方式执行，而是通过 user script 方式。同时加上异常处理，网络错误时返回 "None" ，确保天气和月相栏始终有返回值。 