### PR TITLE
Fix blank heatmap in 2022.md

### DIFF
--- a/Journal/2022/2022.md
+++ b/Journal/2022/2022.md
@@ -13,7 +13,8 @@ dv.paragraph(window.pages.file.link.join(', '))
 ## OKR Tracker
 ### Journal
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -49,7 +50,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -115,7 +117,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -150,7 +153,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -183,7 +187,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 console.log(pages);
@@ -307,7 +312,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -344,7 +350,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -376,7 +383,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 
@@ -409,7 +417,8 @@ dv.el('div', score + '%', {
 });
 ```
 ```dataviewjs
-const calendarData = { 
+const calendarData = {
+	year: 2022,
 	entries: [],
 }
 


### PR DESCRIPTION
By default Heatmap Calendar uses current year as the value of `year` param, which would cause problems for years other than 2022.